### PR TITLE
Add Claude Code skills for TriggerHelper

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,65 @@
+# Claude Code Skills — TriggerHelper Framework
+
+This directory ships two Claude Code skills alongside the TriggerHelper framework.
+When you open this repo in Claude Code, both skills are automatically available as
+slash commands — no manual setup required beyond the prerequisites below.
+
+## Skills
+
+| Skill | Invocation | Purpose |
+|-------|-----------|---------|
+| `triggerhelper-write-helper` | `/triggerhelper-write-helper` | Generate a framework-conformant TriggerHelper implementation from a description of your business logic. Produces the helper class, trigger file, and CMT metadata stub. |
+| `triggerhelper-unit-tests` | `/triggerhelper-unit-tests` | Generate a production-ready unit test class for an existing TriggerHelper using `TestTriggerHelperHarness`. Pure unit tests — no live DML on the object under test. |
+
+## Prerequisites
+
+| Tool | Required for | Install |
+|------|-------------|---------|
+| [Claude Code](https://claude.ai/code) | All skills | Follow Anthropic install guide |
+| [Salesforce CLI (`sf`)](https://developer.salesforce.com/tools/salesforcecli) | Both skills (test execution) | `npm install -g @salesforce/cli` |
+| Git | Both skills | Pre-installed on macOS / Linux |
+
+Authenticate your target org before first use:
+```sh
+sf org login web --alias MY_ORG
+```
+
+## Permissions
+
+The skills run `sf apex test run`, `grep`, and `find` via Claude Code's Bash tool.
+Add the entries from `settings-snippet.json` to your `~/.claude/settings.json` to
+allow these commands without per-call prompts:
+
+```sh
+# View the required snippet
+cat .claude/settings-snippet.json
+```
+
+Merge the `permissions.allow` array into your existing settings file. If you don't
+have a `~/.claude/settings.json` yet, you can copy the snippet as a starting point.
+
+## How the skills work
+
+Both skills read the framework source files (`TestTriggerHelperHarness.cls`,
+`AbstractBaseTriggerHandler.cls`, `LookupDataHandler.cls`, etc.) directly from this
+repo. There is no external path configuration required — the skills resolve all
+framework references relative to the project root.
+
+Your business logic files (`force-app/main/default/classes/MyHelper.cls`) can live in
+this repo or in a separate Salesforce project repo. If in a separate repo, open that
+project in Claude Code and invoke the skill from there — Claude Code will find this
+repo's skills as long as this repo is a dependency or sibling directory. Alternatively,
+copy the `.claude/skills/` folder into your project repo.
+
+## Contributing skills improvements
+
+The skills live in `.claude/skills/` and are plain Markdown — no build step required.
+
+If a framework API change makes a skill instruction incorrect:
+1. Update the relevant `SKILL.md`
+2. Open a PR against `main` with a brief description of what changed and why
+3. Skills are versioned with the framework — breaking API changes should update the
+   skill in the same PR
+
+If you develop a new skill for the framework (e.g. a query topic authoring skill, a
+CMT management skill), contributions are welcome via the same PR process.

--- a/.claude/settings-snippet.json
+++ b/.claude/settings-snippet.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Merge the entries below into the matching sections of your ~/.claude/settings.json.",
+
+  "permissions": {
+    "allow": [
+      "Bash(sf apex test run:*)",
+      "Bash(sf apex run test:*)",
+      "Bash(sf org list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)"
+    ]
+  }
+}

--- a/.claude/skills/triggerhelper-unit-tests/SKILL.md
+++ b/.claude/skills/triggerhelper-unit-tests/SKILL.md
@@ -1,0 +1,259 @@
+# TriggerHelper Unit Test Authoring Skill
+
+Generates production-ready Apex unit tests for TriggerHelper implementations using
+the `TestTriggerHelperHarness` framework. Tests are pure unit tests: no live DML on
+the object under test, helpers exercised in isolation from the full trigger stack.
+
+## Invocation Forms
+
+```
+/triggerhelper-unit-tests <HelperClassName>
+/triggerhelper-unit-tests <HelperClassName> --scenarios <comma-list>
+/triggerhelper-unit-tests          (prompts for scope)
+```
+
+## Step 1 — Identify the Helper Under Test
+
+Accept the helper class name from the invocation argument, or ask:
+> "Which TriggerHelper class needs a test class? Provide the Apex class name."
+
+Read the helper source file from the project:
+- Search under `force-app/main/default/classes/<HelperClassName>.cls`
+- If not found, ask the user to supply the path.
+
+Also read (framework reference — relative to this repo root):
+- `force-app/main/default/classes/TestTriggerHelperHarness.cls` — harness API
+- `force-app/main/default/classes/AbstractBaseTriggerHandler.cls` — dispatcher lifecycle (error handling, addError contract)
+- `force-app/main/default/classes/LookupDataHandler.cls` — query API (requestExternalId / getExternalId / requestItemDetail / getItemDetail)
+- `force-app/main/default/classes/TestUtility.cls` — fake Id generation
+- `force-app/main/default/classes/MockDMLExecutor.cls` — DML mock
+
+## Step 2 — Analyse the Helper
+
+For each overridden lifecycle method, determine:
+
+| Method | Questions to answer |
+|--------|---------------------|
+| `previewBeforeInsert` | What lookup topics are requested, and under what conditions? |
+| `meetsEntryCriteriaBeforeInsert` | What field/state combinations return true vs. false? |
+| `processRecordBeforeInsert` | What mutations happen? What error path exists? |
+| `finalizeBeforeInsert` | Any deferred work (platform events, DML)? |
+| (same pattern for Update, Delete, Undelete phases) | |
+
+Enumerate all observable outcomes that need separate named tests. Include:
+- Happy-path scenarios (each branch through `processRecord`)
+- Entry-criteria negative path (record skipped entirely)
+- Error/fault paths where an exception is expected
+- Bulk scenarios where ordering-sensitive logic could break
+
+## Step 3 — Determine the LookupDataHandler Strategy
+
+Check whether the helper calls `requestExternalId` / `getExternalId` or
+`requestItemDetail` / `getItemDetail`.
+
+**Key rule — match the API to the key type:**
+- **Salesforce Id** (foreign key / lookup field value) → `requestItemDetail(id)` / `getItemDetail(id)`
+- **String external identifier** (e.g. `Group.DeveloperName`, `Product2.StockKeepingUnit`) → `requestExternalId(topic, key)` / `getExternalId(topic, key)`
+
+Using the ExternalId API for a Salesforce Id (or vice versa) is a must-fix misuse.
+
+**For ExternalId topics in tests:**
+- `QueryTopicFactory.context` stays at its default (`'Production'`). Do not set it in test code — the `'UnitTest'` context is reserved for framework-internal tests only.
+- The `TriggerLookupTopic__mdt` record for the topic (Production context) must be deployed to the org.
+- Insert the target record (e.g. a `Group`) in `@TestSetup` so the live Production-context query resolves.
+
+**For Id-based detail topics:**
+- Insert the target SObject in `@TestSetup` and use its real Id.
+
+**For the "lookup not found" path:**
+- Do not insert the target record (or insert one with a different key).
+- `getExternalId` / `getItemDetail` returns `null`, triggering the helper's error path.
+
+### Lookup not-found assertion pattern (pending harness enhancement)
+
+`AbstractBaseTriggerHandler.beforeInsert` catches exceptions thrown from
+`processRecordBeforeInsert`, calls `LoggingUtility.logError(ex, true)`, and calls
+`current.addError(ex.getMessage())`. Helpers must not log directly — they throw narrow,
+meaningful exceptions and delegate all logging to the dispatcher.
+
+Until the harness exposes a mechanism to inspect `addError` state on in-memory SObjects,
+assert the error path by constructing the helper directly:
+
+```apex
+MyHelper helper = new MyHelper();
+helper.setDataHandler(new LookupDataHandler()); // nothing inserted → returns null
+
+try {
+    helper.processRecordBeforeInsert(record);
+    Assert.fail('Expected MyHelper.NotFoundException');
+} catch (MyHelper.NotFoundException ex) {
+    Assert.isTrue(ex.getMessage().contains('expected-key'),
+        'Exception message must identify the missing record');
+}
+```
+
+> **Open design note:** `addError` inspection on in-memory SObjects is a known harness
+> gap. A future harness enhancement will expose this. When it ships, direct-invocation
+> error tests should migrate to the harness pattern.
+
+## Step 4 — Derive the Test Class Name
+
+Apex class name limit: **40 characters**.
+
+Convention: `<HelperClassName>Test` — if that exceeds 40 characters, abbreviate the
+domain prefix (e.g. `FR` for `FulfillmentRequest`, `IS` for `InteractionSummary`).
+
+| Helper class name | Length | Test class name |
+|---|---|---|
+| `FulfillmentRequestOwnerAssignmentHelper` | 39 ✓ | `FROwnerAssignmentHelperTest` (27) |
+| `InteractionSummaryAdvisorTaskHelper` | 36 ✓ | `ISAdvisorTaskHelperTest` (23) |
+
+## Step 5 — Design the Test Methods
+
+Map every scenario to a method name using the `verb_outcome_when_condition` convention:
+
+```
+assignOwner_setsOwnerId_toAnalyst_whenOnlyAnalystPopulated
+assignOwner_setsOwnerId_toConsultant_whenOnlyConsultantPopulated
+assignOwner_doesNotAssign_whenStatusIsNotNew
+assignOwner_logsError_whenQueueNotFound
+assignOwner_bulkInsert_allPermutations_correctlyAssigned
+```
+
+If the user supplies `--scenarios`, validate against this list and flag any gaps.
+
+## Step 6 — Write the Test Class
+
+### Structure
+
+```apex
+/**
+ * @description Unit tests for <HelperClassName>.
+ *              Pure unit tests — no live DML on <ObjectApiName>.
+ *              Helper exercised in isolation via TestTriggerHelperHarness.
+ *
+ * @author <author>
+ * @date <YYYY-MM-DD>
+ */
+@IsTest
+public class <TestClassName> {
+
+    // ========================================================================
+    // Test Setup
+    // ========================================================================
+    @TestSetup
+    static void setup() {
+        // Insert supporting records only (Users, Groups/Queues, related objects).
+        // Never insert the object under test here.
+    }
+
+    // ========================================================================
+    // Happy-Path Scenarios
+    // ========================================================================
+
+    @IsTest
+    static void <scenarioMethodName>() {
+        // Arrange
+        <ObjectType> record = new <ObjectType>(...);
+        // No insert — record stays in memory
+
+        TestTriggerHelperHarness harness = new TestTriggerHelperHarness(<ObjectType>.SObjectType);
+        harness.setDMLExecutor(new MockDMLExecutor());
+        harness.setHelperUnderTest('<HelperClassName>');
+
+        // Act
+        Test.startTest();
+        harness.doInsert(new List<SObject>{ record });
+        Test.stopTest();
+
+        // Assert — before-insert mutations are in-place on the original record list
+        Assert.areEqual(expectedValue, record.<field>, '<assertion message>');
+    }
+
+    // ========================================================================
+    // Entry-Criteria Negative Path
+    // ========================================================================
+
+    // ========================================================================
+    // Error Path
+    // ========================================================================
+    // Direct-invocation pattern until harness addError inspection is available.
+
+    // ========================================================================
+    // Bulk
+    // ========================================================================
+}
+```
+
+### Rules enforced in generated code
+
+1. **No `insert` on the object under test.** Records are constructed in-memory; `Id` set via `TestUtility.generateFakeId()` when needed for update/delete/undelete.
+
+2. **No `Test.isRunningTest()` in production helper code.** Test isolation is achieved through harness mechanics, not production bypasses.
+
+3. **No `@TestVisible` on constants or pure methods in the helper.** Test the public contract.
+
+4. **`Assert.areEqual(expected, actual, message)` — never bare `System.assertEquals`.** Always include a descriptive message as the third argument.
+
+5. **`Assert.isTrue` / `Assert.isFalse` — never bare `System.assert`.** Same message requirement.
+
+6. **One scenario per method.** No multi-scenario test methods.
+
+7. **`Test.startTest()` / `Test.stopTest()` wraps the Act step.**
+
+8. **`@TestSetup` for shared supporting data only.** If a scenario needs unique state that conflicts with shared setup, use an inline local arrange block.
+
+9. **Bulk test uses a mixed-permutation list** (all branches in a single harness call), asserting correct output for each permutation.
+
+10. **Direct-invocation error tests** construct the helper directly, call the lifecycle method, and assert the exception type and message — no harness.
+
+11. **Do not manipulate `QueryTopicFactory.context` in implementor tests.** The `'UnitTest'` context is reserved for framework-internal tests. Implementor tests run against the `'Production'` context (the default). The `TriggerLookupTopic__mdt` record for the topic must be deployed, and the target record inserted in `@TestSetup`.
+
+### Asserting before-insert field mutations
+
+Before-insert mutations are in-place on the original list reference:
+
+```apex
+List<SObject> records = new List<SObject>{ myRecord };
+harness.doInsert(records);
+Assert.areEqual(expectedValue, ((MyObject__c) records[0]).MyField__c,
+    'Field must be set by helper');
+```
+
+### Records with Ids (update / delete / undelete)
+
+```apex
+Id fakeId = TestUtility.generateFakeId(MyObject__c.SObjectType);
+MyObject__c record = new MyObject__c(Id = fakeId, ...);
+harness.doUpdate(new List<SObject>{ record }, new List<SObject>{ oldRecord });
+```
+
+## Step 7 — Write the Output File
+
+Write the test class to the project under test (not this framework repo):
+```
+force-app/main/default/classes/<TestClassName>.cls
+force-app/main/default/classes/<TestClassName>.cls-meta.xml
+```
+
+Standard meta:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+```
+
+## Step 8 — Self-Review Checklist
+
+- [ ] No `insert` of the object under test
+- [ ] No `Test.isRunningTest()` anywhere
+- [ ] No `@TestVisible` on helper constants or pure methods
+- [ ] All `Assert.*` calls include a message argument
+- [ ] Every scenario from Step 5 has a named method
+- [ ] Bulk test covers all permutations in a single harness call
+- [ ] Error-path tests use direct-invocation pattern with exception type + message assertions
+- [ ] `QueryTopicFactory.context` NOT manipulated — Production context used, target record inserted in `@TestSetup`
+- [ ] Test class name ≤ 40 characters
+- [ ] LookupDataHandler API matches key type (Id → detail; string external key → externalId)

--- a/.claude/skills/triggerhelper-write-helper/SKILL.md
+++ b/.claude/skills/triggerhelper-write-helper/SKILL.md
@@ -1,0 +1,161 @@
+# TriggerHelper Implementation Authoring Skill
+
+Generates a production-ready TriggerHelper implementation class from a natural-language
+description of the business logic. The output is framework-conformant and review-ready:
+dispatcher-only trigger body, correct lifecycle method selection, bulk-safe
+LookupDataHandler usage, and narrow exception throwing.
+
+## Invocation Forms
+
+```
+/triggerhelper-write-helper <description of business logic>
+/triggerhelper-write-helper          (prompts for description)
+```
+
+## Step 1 — Gather Requirements
+
+If no description is provided, ask:
+> "Describe the business logic this helper should implement. Include: the SObject, the
+> trigger phase (before/after insert/update/delete), the entry criteria, the field
+> mutations or DML actions, and any lookup dependencies (e.g. a queue, related record)."
+
+Confirm before writing:
+- SObject API name
+- Trigger phase(s) — before insert / after insert / before update / etc.
+- Entry criteria (what makes a record eligible)
+- Core logic per record
+- Any lookups required (and their key type — Salesforce Id or string external key)
+- Error behavior when a required lookup is missing
+
+## Step 2 — Read Framework Reference
+
+Read (relative to this repo root):
+- `force-app/main/default/classes/AbstractBaseTriggerHelper.cls` — base class and virtual methods
+- `force-app/main/default/classes/LookupDataHandler.cls` — query API
+- `force-app/main/default/classes/TriggerDMLHandler.cls` — deferred DML API
+- `force-app/main/default/classes/ITriggerHelper.cls` — interface contract
+
+## Step 3 — Select Lifecycle Methods
+
+Only override the methods the logic actually requires. Default no-op implementations
+in `AbstractBaseTriggerHelper` cover everything not overridden.
+
+| Need | Override |
+|------|----------|
+| Bulk lookup registration | `preview<Phase>` |
+| Record admission gating | `meetsEntryCriteria<Phase>` |
+| Per-record mutation / DML enqueue | `processRecord<Phase>` |
+| Cross-record aggregation or one-time transaction work | `finalize<Phase>` |
+
+Do not override `finalize` unless cross-record aggregation is genuinely required.
+Per-record DML must be delegated to `getDMLHandler().addForInsert/Update/Delete(record)`
+inside `processRecord`, not buffered in an instance field.
+
+## Step 4 — Apply LookupDataHandler Correctly
+
+Match the API to the key type:
+- **Salesforce Id** → `getDataHandler().requestItemDetail(id)` in `preview`, `getDataHandler().getItemDetail(id)` in `processRecord`
+- **String external key** (e.g. `Group.DeveloperName`) → `getDataHandler().requestExternalId(topic, key)` in `preview`, `getDataHandler().getExternalId(topic, key)` in `processRecord`
+
+In `preview`, pre-screen with available fields before registering a lookup to avoid
+unnecessary queries across a bulk batch. Request only what the record needs.
+
+## Step 5 — Apply Exception and Logging Rules
+
+- Helpers **must not** call `Logger.error`, `Logger.debug`, or any logging framework directly.
+- Throw narrow, typed exceptions with meaningful messages when a required condition is unmet.
+- The dispatcher (`AbstractBaseTriggerHandler`) catches all exceptions, calls
+  `LoggingUtility.logError(ex, true)`, and calls `current.addError(ex.getMessage())`.
+- Define inner exception classes for each distinct fault condition.
+- Do not call `Logger.debug(msg, record)` in before-insert context — records have no Id.
+
+## Step 6 — Write the Helper Class
+
+### Structure
+
+```apex
+/**
+ * @description <Business-intent description.>
+ *
+ * @author <author>
+ * @date <YYYY-MM-DD>
+ */
+public with sharing class <HelperClassName> extends AbstractBaseTriggerHelper {
+
+    // Constants
+    private static final String STATUS_<X> = '<value>';
+    private static final String TOPIC_<X>  = '<TopicName>';
+
+    // preview — register lookups needed by processRecord
+    public override void preview<Phase>(final SObject current) {
+        final <SObject__c> record = (<SObject__c>) current;
+        if (<pre-screen condition>) {
+            getDataHandler().requestExternalId(TOPIC_X, record.<Field__c>);
+        }
+    }
+
+    // entry gate — return true for records processRecord should act on
+    public override Boolean meetsEntryCriteria<Phase>(final SObject current) {
+        final <SObject__c> record = (<SObject__c>) current;
+        return <condition>;
+    }
+
+    // per-record action
+    public override void processRecord<Phase>(final SObject current) {
+        final <SObject__c> record = (<SObject__c>) current;
+        // ... mutations or getDMLHandler().addFor<X>(relatedRecord)
+    }
+
+    // Inner exceptions — one per distinct fault condition
+    public class <Name>Exception extends Exception {}
+}
+```
+
+### Naming
+
+- Class name must be ≤ 40 characters and describe business intent, not implementation mechanism.
+  Prefer `<Domain><Action>Helper` (e.g. `CaseOwnerAssignmentHelper`, `ISAdvisorTaskHelper`).
+- Constants: `SCREAMING_SNAKE_CASE`.
+- No `Helper` suffix on exception classes: `NotFoundException`, `MissingQueueException`.
+
+## Step 7 — Write the Trigger and CMT Stub
+
+Also produce:
+1. A thin trigger file:
+```apex
+trigger <SObject>Trigger on <SObject__c> (before insert, ...) {
+    TriggerDispatcher.run();
+}
+```
+
+2. A `TriggerHelperConfig__mdt` custom metadata record stub:
+```xml
+<!-- force-app/main/default/customMetadata/TriggerHelperConfig.<RecordName>.md-meta.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label><RecordName></label>
+    <values><field>HelperClassName__c</field><value xsi:type="xsi:string"><HelperClassName></value></values>
+    <values><field>SObjectType__c</field><value xsi:type="xsi:string"><SObjectApiName></value></values>
+    <values><field>Enabled__c</field><value xsi:type="xsi:boolean">true</value></values>
+    <values><field>ExecutionSequence__c</field><value xsi:type="xsi:double">10</value></values>
+    <values><field>Context__c</field><value xsi:type="xsi:string">Production</value></values>
+    <values><field>IsPilotMode__c</field><value xsi:type="xsi:boolean">false</value></values>
+</CustomMetadata>
+```
+
+Remind the user: the `TriggerLookupTopic__mdt` record for any new lookup topic must also
+be created (Production context and UnitTest context both required if tests use live queries).
+
+## Step 8 — Self-Review Checklist
+
+- [ ] Class name ≤ 40 characters, business-intent named
+- [ ] Only required lifecycle methods overridden
+- [ ] `preview` pre-screens before registering lookups
+- [ ] LookupDataHandler API matches key type (Id → detail; string → externalId)
+- [ ] Per-record DML via `getDMLHandler()`, not buffered in instance field
+- [ ] `finalize` used only when cross-record aggregation genuinely required
+- [ ] No logging calls in helper — narrow typed exceptions only
+- [ ] No `Logger.debug(msg, record)` in before-insert context
+- [ ] Inner exception class(es) defined for each fault condition
+- [ ] Trigger file is dispatcher-only
+- [ ] CMT stub produced with correct field values


### PR DESCRIPTION
## Summary
- Adds Claude Code skill definitions for TriggerHelper unit test authoring and helper implementation
- Adds settings snippet for skill configuration
- Adds `.claude/README.md` documenting the skills

## Test plan
- [ ] Verify skills appear in Claude Code via `/triggerhelper-unit-tests` and `/triggerhelper-write-helper`
- [ ] Confirm settings snippet integrates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)