### PR TITLE
Claude Code skills and framework documentation

### DIFF
--- a/.claude/settings-snippet.json
+++ b/.claude/settings-snippet.json
@@ -12,7 +12,13 @@
       "Bash(git log:*)",
       "Bash(git show:*)",
       "Bash(grep:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(ls:*)",
+      "Bash(readlink:*)",
+      "Bash(sf data query:*)",
+      "Bash(sf project deploy start:*)",
+      "Bash(sf project deploy report:*)",
+      "Bash(sf config get:*)"
     ]
   }
 }

--- a/.claude/skills/triggerhelper-write-helper/SKILL.md
+++ b/.claude/skills/triggerhelper-write-helper/SKILL.md
@@ -128,23 +128,153 @@ trigger <SObject>Trigger on <SObject__c> (before insert, ...) {
 }
 ```
 
-2. A `TriggerHelperConfig__mdt` custom metadata record stub:
+2. A `TriggerHelperConfig__mdt` custom metadata record stub.
+
+**Before generating the XML, determine which SObject field to populate.**
+
+Salesforce does not allow certain standard objects to be selected via the Entity Reference
+picker in CMT records. The framework handles this with two separate fields and two separate
+SOQL queries (CMT does not support OR across a relationship field and a text field).
+
+**Step 1 — Check known exceptions first.**
+
+The following standard objects are known to require `AlternateSObject__c` regardless of
+what `EntityDefinition.IsCustomizable` returns — the CMT Entity Reference picker maintains
+its own internal restricted list that does not match `IsCustomizable`:
+
+- `User`
+- `Task`
+- `Event`
+
+If the SObject is on this list, use `AlternateSObject__c` and skip the query.
+
+**Step 2 — For all other objects, run the EntityDefinition query as a hint:**
+
+```bash
+sf data query --target-org <alias> --query "SELECT QualifiedApiName, IsCustomizable FROM EntityDefinition WHERE QualifiedApiName = '<SObjectApiName>'"
+```
+
+| `IsCustomizable` result | Field to populate |
+|------------------------|-------------------|
+| `true` | `SObjectType__c` — likely safe, but see note below |
+| `false` or no rows returned | `AlternateSObject__c` |
+
+**Important:** `IsCustomizable = true` is a necessary but not sufficient condition for
+`SObjectType__c`. Other standard objects may also be restricted by the CMT picker but not
+yet confirmed. If deployment fails with a "bad value for restricted picklist field" error
+on `SObjectType__c`, switch to `AlternateSObject__c` and add the object to the known
+exceptions list above.
+
+Using the wrong field causes silent failure at runtime — no helpers run and no error is raised.
+
+**Read one of the existing CMT records as the canonical template.**
+
+Check the local project first, then fall back to the framework repo:
+
+```bash
+# Preferred — adopter's own records (already validated against their org)
+ls force-app/main/default/customMetadata/TriggerHelperConfig.*.md-meta.xml 2>/dev/null | head -1
+
+# Fallback — framework repo (always present, symlinked peer directory)
+ls ../TriggerHelper/force-app/main/default/customMetadata/TriggerHelperConfig.*.md-meta.xml 2>/dev/null | head -1
+```
+
+Read whichever file is found first. Use it as the exact template — namespaces, field order, value types,
+and any fields added in future package versions are all authoritative there. Substitute only the fields
+that change:
+- `<label>`, `HelperClassName__c`, `Context__c`, `ExecutionSequence__c`, `IsPilotMode__c`, `RelatedFlows__c`
+- The SObject field pair (`SObjectType__c` / `AlternateSObject__c`) per the `IsCustomizable` determination above
+
+The only critical difference from a test record: `Context__c = Production`.
+
+The templates below are a last-resort fallback only if neither location yields a file.
+
+For most objects — use `SObjectType__c`:
 ```xml
 <!-- force-app/main/default/customMetadata/TriggerHelperConfig.<RecordName>.md-meta.xml -->
 <?xml version="1.0" encoding="UTF-8"?>
-<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata">
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label><RecordName></label>
-    <values><field>HelperClassName__c</field><value xsi:type="xsi:string"><HelperClassName></value></values>
-    <values><field>SObjectType__c</field><value xsi:type="xsi:string"><SObjectApiName></value></values>
-    <values><field>Enabled__c</field><value xsi:type="xsi:boolean">true</value></values>
-    <values><field>ExecutionSequence__c</field><value xsi:type="xsi:double">10</value></values>
-    <values><field>Context__c</field><value xsi:type="xsi:string">Production</value></values>
-    <values><field>IsPilotMode__c</field><value xsi:type="xsi:boolean">false</value></values>
+    <protected>false</protected>
+    <values>
+        <field>AlternateSObject__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Context__c</field>
+        <value xsi:type="xsd:string">Production</value>
+    </values>
+    <values>
+        <field>Enabled__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>ExecutionSequence__c</field>
+        <value xsi:type="xsd:double">10.0</value>
+    </values>
+    <values>
+        <field>HelperClassName__c</field>
+        <value xsi:type="xsd:string"><HelperClassName></value>
+    </values>
+    <values>
+        <field>IsPilotMode__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>RelatedFlows__c</field>
+        <value xsi:type="xsd:string">Not Applicable</value>
+    </values>
+    <values>
+        <field>SObjectType__c</field>
+        <value xsi:type="xsd:string"><SObjectApiName></value>
+    </values>
 </CustomMetadata>
 ```
 
-Remind the user: the `TriggerLookupTopic__mdt` record for any new lookup topic must also
-be created (Production context and UnitTest context both required if tests use live queries).
+For restricted objects (`User`, `Event`, `Task`, etc.) — use `AlternateSObject__c` instead:
+```xml
+<!-- force-app/main/default/customMetadata/TriggerHelperConfig.<RecordName>.md-meta.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label><RecordName></label>
+    <protected>false</protected>
+    <values>
+        <field>AlternateSObject__c</field>
+        <value xsi:type="xsd:string"><SObjectApiName></value>
+    </values>
+    <values>
+        <field>Context__c</field>
+        <value xsi:type="xsd:string">Production</value>
+    </values>
+    <values>
+        <field>Enabled__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>ExecutionSequence__c</field>
+        <value xsi:type="xsd:double">10.0</value>
+    </values>
+    <values>
+        <field>HelperClassName__c</field>
+        <value xsi:type="xsd:string"><HelperClassName></value>
+    </values>
+    <values>
+        <field>IsPilotMode__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>RelatedFlows__c</field>
+        <value xsi:type="xsd:string">Not Applicable</value>
+    </values>
+    <values>
+        <field>SObjectType__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>
+```
+
+Remind the user: a `TriggerLookupTopic__mdt` record is required for any new lookup topic.
+Use `/triggerhelper-write-lookup-topic` to generate it.
 
 ## Step 8 — Self-Review Checklist
 
@@ -158,4 +288,5 @@ be created (Production context and UnitTest context both required if tests use l
 - [ ] No `Logger.debug(msg, record)` in before-insert context
 - [ ] Inner exception class(es) defined for each fault condition
 - [ ] Trigger file is dispatcher-only
-- [ ] CMT stub produced with correct field values
+- [ ] `EntityDefinition` query was run to determine `IsCustomizable` for the target SObject
+- [ ] CMT stub uses `SObjectType__c` if `IsCustomizable = true`, `AlternateSObject__c` otherwise — never both

--- a/.claude/skills/triggerhelper-write-lookup-topic/SKILL.md
+++ b/.claude/skills/triggerhelper-write-lookup-topic/SKILL.md
@@ -1,0 +1,233 @@
+# TriggerHelper Lookup Topic Authoring Skill
+
+Generates or updates a `TriggerLookupTopic__mdt` record for use with `LookupDataHandler`.
+Handles all three topic types: Detail, RelatedList, and ExternalId.
+
+## Invocation Forms
+
+```
+/triggerhelper-write-lookup-topic <description>
+/triggerhelper-write-lookup-topic          (prompts for requirements)
+```
+
+## Step 1 — Gather Requirements
+
+If no description is provided, ask:
+> "Describe the lookup you need. Include: the SObject being queried, what key you're
+> looking up by (a Salesforce Id field, a related Id field, or a string external key),
+> and what fields you need back."
+
+Determine and confirm:
+- **SObject** being queried (the `FROM` object)
+- **Key type** — which of the three topic types applies (see Step 2)
+- **Fields** needed in the SELECT
+- **Topic name** — suggest per convention (see Step 2), allow override
+- **Additional WHERE filters** beyond the `:keySet` bind, if any
+
+## Step 2 — Determine Topic Type and Name
+
+### Detail (DETAIL)
+- **When:** you have a Salesforce Id that is the *primary key* of the target object.
+  e.g. `Case.OwnerId` → look up the `User` record.
+- **Query form:** `SELECT <fields> FROM <SObject> WHERE Id IN :keySet`
+- **`KeyFieldname__c`:** leave null — the framework keys the result map by `Id` implicitly.
+- **Topic name convention:** the SObject API name. e.g. `User`, `Account`, `Queue`.
+  This is the name the framework uses automatically when you call `requestItemDetail(id)`.
+
+### RelatedList (RELATED)
+- **When:** you have the *primary key* of a parent and want its child records.
+  e.g. `Case.Id` → get all `CaseMilestone` records for that case.
+- **Query form:** `SELECT <fields> FROM <ChildSObject> WHERE <ParentIdField> IN :keySet`
+- **`KeyFieldname__c`:** the foreign-key field on the child object (e.g. `CaseId`). This
+  field **must** appear in the SELECT — the framework uses it to group results by parent.
+- **Topic name convention:** `Related<ChildSObjectName>`. e.g. `RelatedCaseMilestones`.
+
+### ExternalId (EXTERNALID)
+- **When:** you have a string value (not a Salesforce Id) that matches a unique field on
+  the target object. e.g. a `StockKeepingUnit` or `FederationIdentifier`.
+- **Query form:** `SELECT <fields> FROM <SObject> WHERE <ExternalIdField> IN :keySet`
+- **`KeyFieldname__c`:** the string field used as the key (e.g. `StockKeepingUnit`,
+  `FederationIdentifier`). This field **must** appear in the SELECT.
+- **Topic name convention:** freeform, but descriptive. e.g. `UserByFederationId`.
+
+## Step 3 — Check for Existing Topic
+
+Before generating a new record, scan local source files for an existing topic with the
+same name and `Context__c = Production`:
+
+```bash
+grep -rl "<value.*>Production</value>" force-app/main/default/customMetadata/TriggerLookupTopic.*.md-meta.xml 2>/dev/null \
+  | xargs grep -l "<value.*><TopicName></value>" 2>/dev/null
+```
+
+Also check the framework repo as a fallback:
+```bash
+grep -rl "<value.*>Production</value>" ../TriggerHelper/force-app/main/default/customMetadata/TriggerLookupTopic.*.md-meta.xml 2>/dev/null \
+  | xargs grep -l "<value.*><TopicName></value>" 2>/dev/null
+```
+
+**If the topic already exists:**
+- Read the existing file.
+- Merge the requested fields into the SELECT field list — the result is the union of all
+  fields. Do not change the WHERE clause, ORDER BY, or any other part of the query.
+- Warn the user: "Verify the merged query in Developer Console or Query Editor before
+  deploying — field validity cannot be confirmed from metadata alone."
+- Update the file in place.
+
+**If the topic does not exist:** proceed to generate a new record.
+
+## Step 4 — Construct the Query Template
+
+Rules that must hold for every generated query:
+1. `:keySet` is the only bind variable — it is bound by the framework, never by the helper.
+2. For **RelatedList** and **ExternalId**, the `KeyFieldname__c` field must appear in the SELECT.
+3. The WHERE clause must filter on `:keySet`:
+   - Detail/RelatedList: `WHERE <keyField> IN :keySet`
+   - ExternalId: `WHERE <externalIdField> IN :keySet`
+4. `Id` should always be in the SELECT.
+5. Additional WHERE filters are appended with `AND`.
+
+Validate the query structure mentally before generating:
+- Every field in SELECT is a real API field name (confirm with user if uncertain).
+- The FROM object matches the SObject being queried.
+- `:keySet` appears exactly once in the WHERE clause.
+
+## Step 5 — Generate the CMT Record
+
+Use an existing `TriggerLookupTopic__mdt` record as the canonical format template.
+Check local project first, then fall back to the framework repo:
+
+```bash
+ls force-app/main/default/customMetadata/TriggerLookupTopic.*.md-meta.xml 2>/dev/null | head -1
+ls ../TriggerHelper/force-app/main/default/customMetadata/TriggerLookupTopic.*.md-meta.xml 2>/dev/null | head -1
+```
+
+Read whichever is found first and use it for correct namespaces, field order, and value types.
+
+**File naming:** `TriggerLookupTopic.<RecordName>.md-meta.xml`
+- Record name should be descriptive and unique. Suggested: `<TopicName>` for the first
+  production record on a topic (e.g. `User`, `RelatedCaseMilestones`).
+
+**Field values:**
+
+| Field | Detail | RelatedList | ExternalId |
+|-------|--------|-------------|------------|
+| `Topic__c` | SObject API name (e.g. `User`) | `Related<ChildSObject>` | Descriptive name |
+| `TopicType__c` | `Detail` | `RelatedList` | `ExternalId` |
+| `SObjectTypeName__c` | SObject API name | Child SObject API name | SObject API name |
+| `KeyFieldname__c` | `xsi:nil="true"` | Parent Id field on child (e.g. `CaseId`) | String key field (e.g. `FederationIdentifier`) |
+| `QueryTemplate__c` | Constructed query | Constructed query | Constructed query |
+| `Context__c` | `Production` | `Production` | `Production` |
+
+Example — Detail (User):
+```xml
+<!-- force-app/main/default/customMetadata/TriggerLookupTopic.User.md-meta.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>User</label>
+    <protected>false</protected>
+    <values>
+        <field>Context__c</field>
+        <value xsi:type="xsd:string">Production</value>
+    </values>
+    <values>
+        <field>KeyFieldname__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>QueryTemplate__c</field>
+        <value xsi:type="xsd:string">SELECT Id, Name, Email FROM User WHERE Id IN :keySet</value>
+    </values>
+    <values>
+        <field>SObjectTypeName__c</field>
+        <value xsi:type="xsd:string">User</value>
+    </values>
+    <values>
+        <field>TopicType__c</field>
+        <value xsi:type="xsd:string">Detail</value>
+    </values>
+    <values>
+        <field>Topic__c</field>
+        <value xsi:type="xsd:string">User</value>
+    </values>
+</CustomMetadata>
+```
+
+Example — RelatedList (CaseMilestones):
+```xml
+<!-- force-app/main/default/customMetadata/TriggerLookupTopic.RelatedCaseMilestones.md-meta.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Related Case Milestones</label>
+    <protected>false</protected>
+    <values>
+        <field>Context__c</field>
+        <value xsi:type="xsd:string">Production</value>
+    </values>
+    <values>
+        <field>KeyFieldname__c</field>
+        <value xsi:type="xsd:string">CaseId</value>
+    </values>
+    <values>
+        <field>QueryTemplate__c</field>
+        <value xsi:type="xsd:string">SELECT Id, CaseId, MilestoneTypeId FROM CaseMilestone WHERE CaseId IN :keySet</value>
+    </values>
+    <values>
+        <field>SObjectTypeName__c</field>
+        <value xsi:type="xsd:string">CaseMilestone</value>
+    </values>
+    <values>
+        <field>TopicType__c</field>
+        <value xsi:type="xsd:string">RelatedList</value>
+    </values>
+    <values>
+        <field>Topic__c</field>
+        <value xsi:type="xsd:string">RelatedCaseMilestones</value>
+    </values>
+</CustomMetadata>
+```
+
+Example — ExternalId (User by FederationIdentifier):
+```xml
+<!-- force-app/main/default/customMetadata/TriggerLookupTopic.UserByFederationId.md-meta.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>User By Federation Id</label>
+    <protected>false</protected>
+    <values>
+        <field>Context__c</field>
+        <value xsi:type="xsd:string">Production</value>
+    </values>
+    <values>
+        <field>KeyFieldname__c</field>
+        <value xsi:type="xsd:string">FederationIdentifier</value>
+    </values>
+    <values>
+        <field>QueryTemplate__c</field>
+        <value xsi:type="xsd:string">SELECT Id, FederationIdentifier, Name FROM User WHERE FederationIdentifier IN :keySet</value>
+    </values>
+    <values>
+        <field>SObjectTypeName__c</field>
+        <value xsi:type="xsd:string">User</value>
+    </values>
+    <values>
+        <field>TopicType__c</field>
+        <value xsi:type="xsd:string">ExternalId</value>
+    </values>
+    <values>
+        <field>Topic__c</field>
+        <value xsi:type="xsd:string">UserByFederationId</value>
+    </values>
+</CustomMetadata>
+```
+
+## Step 6 — Self-Review Checklist
+
+- [ ] Topic type correctly identified (Detail / RelatedList / ExternalId)
+- [ ] Topic name follows convention (suggested, confirmed with user if overridden)
+- [ ] `:keySet` appears exactly once in the WHERE clause
+- [ ] `KeyFieldname__c` is null for Detail; set and present in SELECT for RelatedList and ExternalId
+- [ ] `Id` is in the SELECT
+- [ ] `Context__c = Production`
+- [ ] If topic existed: only SELECT field list was changed; user warned to validate query
+- [ ] XML format matches the canonical template from local or framework source files

--- a/CLAUDE-framework-adopter.md
+++ b/CLAUDE-framework-adopter.md
@@ -1,0 +1,254 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+TriggerHelper is an installed unlocked package (`TriggerHelperFramework`). You write helpers in **your** project; the framework classes (`AbstractBaseTriggerHelper`, `TriggerDispatcher`, etc.) live in the package namespace and are not editable.
+
+---
+
+## Writing a trigger
+
+Every trigger is one line:
+
+```apex
+trigger AccountTrigger on Account (before insert, before update, after insert, after update, before delete, after delete, after undelete) {
+    TriggerDispatcher.run();
+}
+```
+
+---
+
+## Writing a helper
+
+Extend `AbstractBaseTriggerHelper` and override only the phase methods you need. All others are no-ops by default.
+
+```apex
+public class AccountStatusHelper extends AbstractBaseTriggerHelper {
+
+    // Optional: register bulk queries before records are evaluated
+    public override void previewAfterUpdate(SObject current, SObject original) {
+        Account acct = (Account) current;
+        if (acct.OwnerId != ((Account) original).OwnerId) {
+            getDataHandler().requestItemDetail(acct.OwnerId);  // User lookup
+        }
+    }
+
+    public override Boolean meetsEntryCriteriaAfterUpdate(SObject current, SObject original) {
+        return ((Account) current).OwnerId != ((Account) original).OwnerId;
+    }
+
+    public override void processRecordAfterUpdate(SObject current, SObject original) {
+        Account acct = (Account) current;
+        User newOwner = (User) getDataHandler().getItemDetail(acct.OwnerId);
+        Account toUpdate = (Account) getDMLHandler().getForUpdate(acct);
+        toUpdate.Description = 'Owner changed to ' + newOwner.Name;
+        getDMLHandler().putForUpdate(toUpdate);
+    }
+}
+```
+
+**Rules:**
+- Never write SOQL inside `meetsEntryCriteria*` or `processRecord*` — register keys in `preview*`, retrieve in `processRecord*`
+- Never call DML directly — queue everything through `getDMLHandler()`
+- No logging in helpers — handled by the framework layer
+
+---
+
+## Helper lifecycle (per trigger phase)
+
+```
+For each record → preview*(record)          register query keys
+                                            [framework executes batch queries]
+               → meetsEntryCriteria*(record) return false to skip
+               → processRecord*(record)      business logic; queue DML
+After all records → finalize*()             cross-record aggregation
+                  [framework executes deferred DML]
+```
+
+---
+
+## Bulk queries — LookupDataHandler
+
+Three patterns, all accessed via `getDataHandler()`:
+
+**Detail lookup** (foreign key → primary key of target):
+```apex
+// preview: register
+getDataHandler().requestItemDetail(acct.OwnerId);            // topic = SObjectType of the Id
+
+// processRecord: retrieve
+User owner = (User) getDataHandler().getItemDetail(acct.OwnerId);
+```
+
+**Related list** (primary key → child records):
+```apex
+// preview: register
+getDataHandler().requestRelatedList('CaseMilestones', caseRecord.Id);
+
+// processRecord: retrieve (always returns a list, never null)
+List<SObject> milestones = getDataHandler().getRelatedList('CaseMilestones', caseRecord.Id);
+```
+
+**External ID lookup** (string key → record):
+```apex
+// preview: register
+getDataHandler().requestExternalId('MyTopic', record.External_Id__c);
+
+// processRecord: retrieve
+SObject related = getDataHandler().getExternalId('MyTopic', record.External_Id__c);
+```
+
+Topic names for related list and external ID queries must match a `TriggerLookupTopic__mdt` record (see below).
+
+---
+
+## Deferred DML — TriggerDMLHandler
+
+Accessed via `getDMLHandler()`:
+
+| Operation | Methods |
+|-----------|---------|
+| Insert | `addForInsert(record)` — record must have no Id |
+| Update | `getForUpdate(record)` then `putForUpdate(record)` — merges edits from multiple helpers |
+| Upsert | `getForUpsert(record, externalIdField)` then `putForUpsert(record, externalIdField)` |
+| Delete | `addForDelete(record)` — record must have Id |
+| Undelete | `addForUnDelete(record)` |
+| Platform Event | `addForPublish(event)` |
+
+Always `getFor*` before `putFor*` on update/upsert — this prevents one helper from overwriting another helper's field changes on the same record.
+
+---
+
+## Configuration — TriggerHelperConfig__mdt
+
+One record per helper. Fields:
+
+| Field | Purpose |
+|-------|---------|
+| `SObjectType__c` | Entity Reference to the SObject — use when `IsCustomizable = true` (see below) |
+| `AlternateSObject__c` | Plain-text API name fallback — use when `IsCustomizable = false`. Leave `SObjectType__c` blank. |
+| `HelperClassName__c` | Apex class name (e.g. `AccountStatusHelper`) |
+| `ExecutionSequence__c` | Integer — ascending order of execution |
+| `Enabled__c` | Boolean on/off without code change |
+| `Context__c` | `Production` for live helpers; use a separate value for test-only records |
+| `IsPilotMode__c` | Gates on `FF_TriggerHelperPilot` custom permission |
+| `RelatedFlows__c` | Required text field. Document any Flows that must be deactivated when this helper is active (they are mutually exclusive). If no flows are related, set to `Not Applicable`. |
+
+A record must populate **either** `SObjectType__c` **or** `AlternateSObject__c`, never both. The factory runs two separate SOQL queries because CMT does not support OR across a relationship field and a text field. Using the wrong field causes silent failure — no helpers run and no error is raised.
+
+Some standard objects are known to require `AlternateSObject__c` regardless of other signals —
+the CMT Entity Reference picker has its own internal restricted list. Known cases: `User`, `Task`, `Event`.
+For these, use `AlternateSObject__c` directly.
+
+For all other objects, query `EntityDefinition` as a guide:
+
+```bash
+sf data query --target-org <alias> --query "SELECT QualifiedApiName, IsCustomizable FROM EntityDefinition WHERE QualifiedApiName = '<SObjectApiName>'"
+```
+
+If `IsCustomizable = true` → try `SObjectType__c`. If `false` (or no rows) → use `AlternateSObject__c`.
+
+The definitive test is deployment — if it fails with a "bad value for restricted picklist field" error,
+switch to `AlternateSObject__c`.
+
+---
+
+## Configuration — TriggerLookupTopic__mdt
+
+One record per query topic. There are three topic types — choose based on what key you have
+and what shape of result you need.
+
+### Detail
+You have a Salesforce Id that is the primary key of the target object (e.g. `Case.OwnerId` → `User`).
+- `Topic__c` — the SObject API name (e.g. `User`). This is what the framework resolves automatically when you call `requestItemDetail(id)`.
+- `TopicType__c` — `Detail`
+- `KeyFieldname__c` — leave null. The result map is keyed by `Id` implicitly.
+- `QueryTemplate__c` — `SELECT Id, <fields> FROM <SObject> WHERE Id IN :keySet`
+
+### RelatedList
+You have the primary key of a parent and want its child records (e.g. `Case.Id` → `CaseMilestone` list).
+- `Topic__c` — descriptive name, convention is `Related<ChildSObject>` (e.g. `RelatedCaseMilestones`). This is the name passed to `requestRelatedList(topic, id)`.
+- `TopicType__c` — `RelatedList`
+- `KeyFieldname__c` — the foreign-key field on the child object (e.g. `CaseId`). **Must appear in the SELECT** — the framework uses it to group results by parent.
+- `QueryTemplate__c` — `SELECT Id, <KeyFieldname__c>, <fields> FROM <ChildSObject> WHERE <KeyFieldname__c> IN :keySet`
+
+### ExternalId
+You have a string value (not a Salesforce Id) that matches a unique field on the target object (e.g. `FederationIdentifier`, `StockKeepingUnit`).
+- `Topic__c` — descriptive name (e.g. `UserByFederationId`). This is the name passed to `requestExternalId(topic, key)`.
+- `TopicType__c` — `ExternalId`
+- `KeyFieldname__c` — the string field used as the key (e.g. `FederationIdentifier`). **Must appear in the SELECT**.
+- `QueryTemplate__c` — `SELECT Id, <KeyFieldname__c>, <fields> FROM <SObject> WHERE <KeyFieldname__c> IN :keySet`
+
+**Common rules for all types:**
+- `:keySet` is the only bind variable — it is bound by the framework, never by the helper.
+- `Context__c = Production` for all live records.
+- `SObjectTypeName__c` — the API name of the queried SObject. Documentation only, not used at runtime.
+- If a topic for the same SObject already exists (e.g. a `User` Detail topic shared by multiple helpers), add your needed fields to the existing query's SELECT rather than creating a duplicate. Validate the merged query in Developer Console before deploying.
+
+---
+
+## Testing
+
+Use `TestTriggerHelperHarness`. It isolates a single helper and mocks DML — no live DML on the object under test.
+
+```apex
+@isTest
+static void testOwnerChange() {
+    // Setup: build in-memory records (no insert on target object)
+    Account oldAcct = new Account(Id = TestUtility.generateFakeId(Account.SObjectType), OwnerId = UserInfo.getUserId());
+    Account newAcct = new Account(Id = oldAcct.Id, OwnerId = UserInfo.getOrganizationId()); // different owner
+
+    TestTriggerHelperHarness harness = new TestTriggerHelperHarness(Account.SObjectType);
+    harness.setHelperUnderTest('AccountStatusHelper');
+    harness.doUpdate(new List<SObject>{newAcct}, new List<SObject>{oldAcct});
+
+    // Verify deferred DML
+    TriggerDMLHandler dmlHandler = harness.getDMLHandler();
+    Assert.isFalse(dmlHandler.toUpdate.isEmpty());
+    Account updated = (Account) dmlHandler.toUpdate.values()[0];
+    Assert.isTrue(updated.Description.contains('Owner changed'));
+}
+```
+
+**Harness entry points:**
+
+| Method | Phases run |
+|--------|-----------|
+| `doInsert(newRecords)` | before insert + after insert (auto-assigns mock Ids) |
+| `doUpdate(newRecords, oldRecords)` | before update + after update |
+| `doDelete(deletedRecords)` | before delete + after delete |
+| `doUndelete(undeletedRecords)` | after undelete only |
+
+**Accessing results:**
+
+| Method | Returns |
+|--------|---------|
+| `harness.getDMLHandler()` | `TriggerDMLHandler` — inspect `.toInsert`, `.toUpdate`, `.toDelete`, `.toPublish` |
+| `harness.getBeforePhaseHelper()` | `ITriggerHelper` instance from the before phase |
+| `harness.getAfterPhaseHelper()` | `ITriggerHelper` instance from the after phase |
+
+Records passed to `doUpdate`, `doDelete`, `doUndelete` must already have Ids. Use `TestUtility.generateFakeId(SObjectType)` for in-memory Ids, or insert dependent/parent records in `@TestSetup` and read their Ids.
+
+---
+
+## Claude Code skills
+
+If you have cloned the TriggerHelper repository as a peer to this project, you can link the authoring skills:
+
+```bash
+# From your project root
+ln -s ../TriggerHelper/.claude/skills/triggerhelper-write-helper .claude/skills/
+ln -s ../TriggerHelper/.claude/skills/triggerhelper-unit-tests .claude/skills/
+```
+
+Then invoke them as:
+- `/triggerhelper-write-helper` — generates a helper class + trigger + CMT stub for a given SObject and use case
+- `/triggerhelper-unit-tests` — generates a test class using `TestTriggerHelperHarness` for an existing helper
+
+To keep framework documentation current in your project's `CLAUDE.md`, add this import (adjust relative path if your layout differs):
+
+```
+@../TriggerHelper/CLAUDE-framework-adopter.md
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+**Full scratch org cycle (create → deploy → test → delete):**
+```bash
+./dev_scratch_cycle.sh
+```
+Configuration in `project.properties` (`DEV_HUB_ALIAS`, `SCRATCH_ALIAS`, `NEBULA_ALIAS`).
+
+**Deploy source to existing scratch org:**
+```bash
+sf project deploy start --target-org THF_DEV
+```
+
+**Run all Apex tests:**
+```bash
+sf apex test run --target-org THF_DEV --synchronous --result-format human
+```
+
+**Run a single test class:**
+```bash
+sf apex test run --target-org THF_DEV --class-names TriggerHelperFactoryTest --synchronous --result-format human
+```
+
+**Lint / format:**
+```bash
+npm run prettier          # format in place
+npm run prettier:verify   # check only (CI-style)
+```
+
+**Publish unlocked package version:**
+```bash
+./publish_package_version.sh
+```
+
+## Architecture
+
+Every trigger calls `TriggerDispatcher.run()` — that's the only line in a trigger file.
+
+**Dispatch chain:**
+```
+TriggerDispatcher.run()
+  → TriggerHandlerFactory (routes SObjectType → StandardSObjectTriggerHandler or StandardPlatformEventTriggerHandler)
+  → TriggerHelperFactory (reads TriggerHelperConfig__mdt, filters by SObject + Context + pilot mode, instantiates helpers in ExecutionSequence order)
+  → AbstractBaseTriggerHandler.executeTriggerPhase()
+      1. helper.preview*()          — register SOQL topics with LookupDataHandler
+      2. QueryTopicFactory          — loads TriggerLookupTopic__mdt, executes batch queries
+      3. helper.meetsEntryCriteria*() — per-record gate
+      4. helper.processRecord*()    — per-record business logic (DML deferred via TriggerDMLHandler)
+      5. helper.finalize*()         — cross-record aggregation
+      6. TriggerDMLHandler.execute() — execute batched DML via DMLExecutor
+```
+
+**Key abstractions:**
+- `ITriggerHelper` — contract for all helpers: `preview*`, `meetsEntryCriteria*`, `processRecord*`, `finalize*` per phase
+- `AbstractBaseTriggerHelper` — no-op defaults; subclass and override only the methods needed
+- `LookupDataHandler` — two bulk query patterns: (1) detail via Id lookup, (2) related list via foreign key
+- `TriggerDMLHandler` — defers and batches DML by operation type; never do direct DML in helpers
+- `TriggerHelperConfig__mdt` — wires helpers to objects (SObjectType, HelperClassName, ExecutionSequence, Context, IsPilotMode)
+- `TriggerLookupTopic__mdt` — defines SOQL query templates (Topic, SObjectTypeName, KeyFieldname, QueryTemplate, TopicType, Context)
+
+**Contexts:** CMT records carry a `Context__c` field. Production helpers use `Production`. Unit/factory tests use separate context values so test-only configs don't leak into production dispatch.
+
+**Pilot mode:** Set `IsPilotMode__c = true` on a CMT record to gate that helper behind the `FF_TriggerHelperPilot` custom permission.
+
+## Testing
+
+Tests use `TestTriggerHelperHarness` — a subclass of `StandardSObjectTriggerHandler` that isolates a single helper and mocks DML execution. There is no live DML on the object under test; test records are built in memory only.
+
+**Pattern:**
+```apex
+TestTriggerHelperHarness harness = new TestTriggerHelperHarness(new MyHelper());
+harness.runBeforeInsert(records);          // or runAfterUpdate(newRecords, oldMap), etc.
+MockDMLExecutor mockDml = harness.getMockDMLExecutor();
+// Assert on mockDml.getInsertedRecords(), getUpdatedRecords(), etc.
+```
+
+- Use `TestUtility.generateFakeId(SObjectType)` for non-insert scenarios where real Ids are needed.
+- `@TestSetup` is for dependent/lookup records only — never the target object.
+- `TestDataFactory` for building SObject instances.
+- Direct handler invocation (bypassing harness) is acceptable only for error/exception path tests.
+
+## Claude Code Skills
+
+Two project skills accelerate new helper and test authoring:
+
+| Skill | Invocation | Output |
+|-------|-----------|--------|
+| `triggerhelper-write-helper` | `/triggerhelper-write-helper` | Helper class + trigger file + CMT stub |
+| `triggerhelper-unit-tests` | `/triggerhelper-unit-tests` | Unit test class using `TestTriggerHelperHarness` |
+
+Skills read the framework source directly. See `.claude/README.md` for prerequisites and permissions setup.
+
+## Conventions
+
+- **No logging in helpers.** All logging goes through `LoggingUtility` (Nebula Logger wrapper), called from the handler layer.
+- **No direct DML in helpers.** Queue everything through `getDMLHandler()`.
+- **Narrow exceptions.** Throw specific typed exceptions, not `Exception`.
+- **Bulk-safe queries.** Use `LookupDataHandler.request*` in `preview*` methods; never SOQL inside loops.
+- `DesignByContractUtil` — use for precondition/postcondition assertions, not ad-hoc `if (x == null) throw`.
+
+## Dependencies
+
+- **Nebula Logger 4.16.5** — only external dependency; installed from package ID `04tKe0000011N4KIAU` during scratch org init.
+- **Salesforce API version:** 62.0
+- **Unlocked package:** TriggerHelperFramework (`0HoDn000000oM1cKAE`)

--- a/README.md
+++ b/README.md
@@ -50,11 +50,18 @@ public class MyFirstAccountHelper extends AbstractBaseTriggerHelper implements I
         
 }
 ```
-4) Create a Custom Metadata Type record configuration (TriggerHelperConfig_mdt)
+4) Create a Custom Metadata Type record configuration (TriggerHelperConfig__mdt)
  - Configure the object (Account)
  - Set the HelperClass name to your helper (MyFirstAccountHelper)
  - Set the Execution Order to 1
  - Enable it
+
+> **Note — User, Event, Task, and other restricted objects:**
+> Salesforce does not allow certain standard objects (including `User`, `Event`, and `Task`) to be
+> selected via the Entity Reference picker in Custom Metadata Type records. For these objects,
+> leave `SObjectType__c` blank and populate `AlternateSObject__c` with the plain API name
+> (e.g. `User`) instead. The framework queries both fields, so behavior is identical at runtime —
+> only the way the CMT record is populated differs.
 
 # TriggerHelperFramework Scratch Org Automation
 


### PR DESCRIPTION
## Summary
- Adds Claude Code skills for TriggerHelper authoring (`triggerhelper-write-helper`, `triggerhelper-unit-tests`, `triggerhelper-write-lookup-topic`)
- Adds `.claude/README.md` with prerequisites and permissions setup for skills
- Adds `.claude/settings-snippet.json` with recommended tool allowlist
- Adds `CLAUDE.md` with project architecture, commands, testing patterns, and conventions
- Adds `CLAUDE-framework-adopter.md` with adopter-specific onboarding guidance
- Updates `README.md` with brief Claude Code skills reference

## Test plan
- [ ] Verify skill invocations resolve correctly in Claude Code CLI
- [ ] Confirm `CLAUDE.md` commands match current scratch org workflow
- [ ] Review `CLAUDE-framework-adopter.md` for adopter accuracy